### PR TITLE
Beat Saber 1.35.0 update

### DIFF
--- a/Camera2.csproj
+++ b/Camera2.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
@@ -13,56 +14,61 @@
     <Company />
     <Authors>Kinsi55</Authors>
     <Copyright>Kinsi55</Copyright>
-    <RepositoryType>
-    </RepositoryType>
+    <RepositoryType></RepositoryType>
     <RepositoryUrl>https://github.com/kinsi55/CS_BeatSaber_Camera2</RepositoryUrl>
-    <Description>
-    </Description>
+    <Description></Description>
     <Platforms>x64</Platforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Configurations>Debug;Release;Dev</Configurations>
   </PropertyGroup>
+
   <Import Project="SuppressRefereces.targets" />
+
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Dev'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
     <OutputPath>bin\Debug</OutputPath>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)' == 'Dev' ">
     <DefineConstants>TRACE;DEBUG;DEV</DefineConstants>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugType>none</DebugType>
     <OutputPath>bin\</OutputPath>
   </PropertyGroup>
+
   <PropertyGroup Condition="$(DefineConstants.Contains('CIBuild')) OR '$(NCrunch)' == '1'">
     <DisableCopyToPlugins>True</DisableCopyToPlugins>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(NCrunch)' == '1'">
     <DisableCopyToPlugins>True</DisableCopyToPlugins>
     <DisableZipRelease>True</DisableZipRelease>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Remove="Utils\BloomShite.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <None Remove="Shaders\camera2utils" />
     <None Remove="Shaders\camera2utilsvr" />
     <None Remove="UI\Views\camPreview.bsml" />
   </ItemGroup>
+
   <ItemGroup>
     <Reference Include="0Harmony">
       <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
+
     </Reference>
     <Reference Include="BeatmapCore, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatmapCore.dll</HintPath>
-    </Reference>
-    <Reference Include="Main, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL" Publicize="true">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
+
     </Reference>
     <Reference Include="BGLib.AppFlow">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.AppFlow.dll</HintPath>
@@ -77,9 +83,6 @@
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="BSML">
-      <HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
-    </Reference>
     <Reference Include="Colors">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Colors.dll</HintPath>
       <Private>False</Private>
@@ -90,68 +93,89 @@
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="MediaLoader">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\MediaLoader.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="BSML">
+      <HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
+
+    </Reference>
     <Reference Include="GameplayCore">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\GameplayCore.dll</HintPath>
+
     </Reference>
     <Reference Include="Hive.Versioning">
       <HintPath>$(BeatSaberDir)\Libs\Hive.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="HMRendering">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMRendering.dll</HintPath>
+
     </Reference>
-    <Reference Include="MediaLoader">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\MediaLoader.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="Microsoft.CSharp">
-    </Reference>
+    <Reference Include="Microsoft.CSharp"></Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>$(BeatSaberDir)\Libs\Newtonsoft.Json.dll</HintPath>
+
+    </Reference>
+    <Reference Include="Oculus.VR">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Oculus.VR.dll</HintPath>
+
     </Reference>
     <Reference Include="Rendering">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Rendering.dll</HintPath>
+
     </Reference>
     <Reference Include="SemVer">
       <HintPath>$(BeatSaberDir)\Libs\SemVer.dll</HintPath>
     </Reference>
     <Reference Include="SongCore">
       <HintPath>$(BeatSaberDir)\Plugins\SongCore.dll</HintPath>
+
     </Reference>
-    <Reference Include="System">
-    </Reference>
-    <Reference Include="System.Core">
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-    </Reference>
-    <Reference Include="System.Data">
+    <Reference Include="System"></Reference>
+    <Reference Include="System.Core"></Reference>
+    <Reference Include="System.Data.DataSetExtensions"></Reference>
+    <Reference Include="System.Data"></Reference>
+    <Reference Include="Main" Publicize="true">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
+
     </Reference>
     <Reference Include="HMLib">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMLib.dll</HintPath>
+
     </Reference>
     <Reference Include="HMUI">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMUI.dll</HintPath>
+
     </Reference>
     <Reference Include="IPA.Loader">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
+
     </Reference>
     <Reference Include="Unity.TextMeshPro">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+
     </Reference>
     <Reference Include="UnityEngine">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
+
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
+
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+
     </Reference>
     <Reference Include="UnityEngine.ScreenCaptureModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.ScreenCaptureModule.dll</HintPath>
@@ -161,26 +185,33 @@
     </Reference>
     <Reference Include="UnityEngine.UI">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UI.dll</HintPath>
+
     </Reference>
     <Reference Include="UnityEngine.UIElementsModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UIElementsModule.dll</HintPath>
+
     </Reference>
     <Reference Include="UnityEngine.UIModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+
     </Reference>
     <Reference Include="UnityEngine.VRModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.VRModule.dll</HintPath>
+
     </Reference>
     <Reference Include="UnityEngine.XRModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.XRModule.dll</HintPath>
     </Reference>
     <Reference Include="VRUI">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\VRUI.dll</HintPath>
+
     </Reference>
   </ItemGroup>
+
   <ItemGroup>
     <None Include="Utils\BloomShite.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="manifest.json" />
     <EmbeddedResource Include="Shaders\camera2utils" />
@@ -190,6 +221,7 @@
     <EmbeddedResource Include="UI\Views\camSettings.bsml" />
     <EmbeddedResource Include="UI\Views\customScenesList.bsml" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="BeatSaberModdingTools.Tasks" Version="1.3.2">
       <PrivateAssets>all</PrivateAssets>
@@ -200,28 +232,28 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
   <ItemGroup>
-    <Reference Update="System.Drawing">
-    </Reference>
+    <Reference Update="System.Drawing"></Reference>
   </ItemGroup>
+
   <ItemGroup>
-    <Reference Update="System.IO.Compression.FileSystem">
-    </Reference>
+    <Reference Update="System.IO.Compression.FileSystem"></Reference>
   </ItemGroup>
+
   <ItemGroup>
-    <Reference Update="System.Numerics">
-    </Reference>
+    <Reference Update="System.Numerics"></Reference>
   </ItemGroup>
+
   <ItemGroup>
-    <Reference Update="System.Runtime.Serialization">
-    </Reference>
+    <Reference Update="System.Runtime.Serialization"></Reference>
   </ItemGroup>
+
   <ItemGroup>
-    <Reference Update="System.Xml">
-    </Reference>
+    <Reference Update="System.Xml"></Reference>
   </ItemGroup>
+
   <ItemGroup>
-    <Reference Update="System.Xml.Linq">
-    </Reference>
+    <Reference Update="System.Xml.Linq"></Reference>
   </ItemGroup>
 </Project>

--- a/Camera2.csproj
+++ b/Camera2.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
@@ -14,61 +13,56 @@
     <Company />
     <Authors>Kinsi55</Authors>
     <Copyright>Kinsi55</Copyright>
-    <RepositoryType></RepositoryType>
+    <RepositoryType>
+    </RepositoryType>
     <RepositoryUrl>https://github.com/kinsi55/CS_BeatSaber_Camera2</RepositoryUrl>
-    <Description></Description>
+    <Description>
+    </Description>
     <Platforms>x64</Platforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Configurations>Debug;Release;Dev</Configurations>
   </PropertyGroup>
-
   <Import Project="SuppressRefereces.targets" />
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Dev'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
     <OutputPath>bin\Debug</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Dev' ">
     <DefineConstants>TRACE;DEBUG;DEV</DefineConstants>
   </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugType>none</DebugType>
     <OutputPath>bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup Condition="$(DefineConstants.Contains('CIBuild')) OR '$(NCrunch)' == '1'">
     <DisableCopyToPlugins>True</DisableCopyToPlugins>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(NCrunch)' == '1'">
     <DisableCopyToPlugins>True</DisableCopyToPlugins>
     <DisableZipRelease>True</DisableZipRelease>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Remove="Utils\BloomShite.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="Shaders\camera2utils" />
     <None Remove="Shaders\camera2utilsvr" />
     <None Remove="UI\Views\camPreview.bsml" />
   </ItemGroup>
-
   <ItemGroup>
     <Reference Include="0Harmony">
       <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
-
     </Reference>
     <Reference Include="BeatmapCore, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatmapCore.dll</HintPath>
-
+    </Reference>
+    <Reference Include="Main, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL" Publicize="true">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
     </Reference>
     <Reference Include="BGLib.AppFlow">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.AppFlow.dll</HintPath>
@@ -78,88 +72,86 @@
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.UnityExtension.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="BGNet">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGNet.dll</HintPath>
-
+    <Reference Include="BGNetCore">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGNetCore.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="BSML">
       <HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
-
+    </Reference>
+    <Reference Include="Colors">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Colors.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="DataModels">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\DataModels.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="GameplayCore">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\GameplayCore.dll</HintPath>
-
     </Reference>
     <Reference Include="Hive.Versioning">
       <HintPath>$(BeatSaberDir)\Libs\Hive.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="HMRendering">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMRendering.dll</HintPath>
-
     </Reference>
-    <Reference Include="Microsoft.CSharp"></Reference>
+    <Reference Include="MediaLoader">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\MediaLoader.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Microsoft.CSharp">
+    </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>$(BeatSaberDir)\Libs\Newtonsoft.Json.dll</HintPath>
-
-    </Reference>
-    <Reference Include="Oculus.VR">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Oculus.VR.dll</HintPath>
-
     </Reference>
     <Reference Include="Rendering">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Rendering.dll</HintPath>
-
     </Reference>
     <Reference Include="SemVer">
       <HintPath>$(BeatSaberDir)\Libs\SemVer.dll</HintPath>
     </Reference>
     <Reference Include="SongCore">
       <HintPath>$(BeatSaberDir)\Plugins\SongCore.dll</HintPath>
-
     </Reference>
-    <Reference Include="System"></Reference>
-    <Reference Include="System.Core"></Reference>
-    <Reference Include="System.Data.DataSetExtensions"></Reference>
-    <Reference Include="System.Data"></Reference>
-    <Reference Include="Main" Publicize="true">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
-
+    <Reference Include="System">
+    </Reference>
+    <Reference Include="System.Core">
+    </Reference>
+    <Reference Include="System.Data.DataSetExtensions">
+    </Reference>
+    <Reference Include="System.Data">
     </Reference>
     <Reference Include="HMLib">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMLib.dll</HintPath>
-
     </Reference>
     <Reference Include="HMUI">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMUI.dll</HintPath>
-
     </Reference>
     <Reference Include="IPA.Loader">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
-
     </Reference>
     <Reference Include="Unity.TextMeshPro">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-
     </Reference>
     <Reference Include="UnityEngine">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
-
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
-
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
-
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
-
     </Reference>
     <Reference Include="UnityEngine.ScreenCaptureModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.ScreenCaptureModule.dll</HintPath>
@@ -169,33 +161,26 @@
     </Reference>
     <Reference Include="UnityEngine.UI">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UI.dll</HintPath>
-
     </Reference>
     <Reference Include="UnityEngine.UIElementsModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UIElementsModule.dll</HintPath>
-
     </Reference>
     <Reference Include="UnityEngine.UIModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UIModule.dll</HintPath>
-
     </Reference>
     <Reference Include="UnityEngine.VRModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.VRModule.dll</HintPath>
-
     </Reference>
     <Reference Include="UnityEngine.XRModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.XRModule.dll</HintPath>
     </Reference>
     <Reference Include="VRUI">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\VRUI.dll</HintPath>
-
     </Reference>
   </ItemGroup>
-
   <ItemGroup>
     <None Include="Utils\BloomShite.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="manifest.json" />
     <EmbeddedResource Include="Shaders\camera2utils" />
@@ -205,7 +190,6 @@
     <EmbeddedResource Include="UI\Views\camSettings.bsml" />
     <EmbeddedResource Include="UI\Views\customScenesList.bsml" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="BeatSaberModdingTools.Tasks" Version="1.3.2">
       <PrivateAssets>all</PrivateAssets>
@@ -216,28 +200,28 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
-    <Reference Update="System.Drawing"></Reference>
+    <Reference Update="System.Drawing">
+    </Reference>
   </ItemGroup>
-
   <ItemGroup>
-    <Reference Update="System.IO.Compression.FileSystem"></Reference>
+    <Reference Update="System.IO.Compression.FileSystem">
+    </Reference>
   </ItemGroup>
-
   <ItemGroup>
-    <Reference Update="System.Numerics"></Reference>
+    <Reference Update="System.Numerics">
+    </Reference>
   </ItemGroup>
-
   <ItemGroup>
-    <Reference Update="System.Runtime.Serialization"></Reference>
+    <Reference Update="System.Runtime.Serialization">
+    </Reference>
   </ItemGroup>
-
   <ItemGroup>
-    <Reference Update="System.Xml"></Reference>
+    <Reference Update="System.Xml">
+    </Reference>
   </ItemGroup>
-
   <ItemGroup>
-    <Reference Update="System.Xml.Linq"></Reference>
+    <Reference Update="System.Xml.Linq">
+    </Reference>
   </ItemGroup>
 </Project>

--- a/Camera2.sln
+++ b/Camera2.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34408.163
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Camera2", "Camera2.csproj", "{FBC84B56-E43F-4552-9711-093603617EAE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Dev|x64 = Dev|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FBC84B56-E43F-4552-9711-093603617EAE}.Debug|x64.ActiveCfg = Debug|x64
+		{FBC84B56-E43F-4552-9711-093603617EAE}.Debug|x64.Build.0 = Debug|x64
+		{FBC84B56-E43F-4552-9711-093603617EAE}.Dev|x64.ActiveCfg = Dev|x64
+		{FBC84B56-E43F-4552-9711-093603617EAE}.Dev|x64.Build.0 = Dev|x64
+		{FBC84B56-E43F-4552-9711-093603617EAE}.Release|x64.ActiveCfg = Release|x64
+		{FBC84B56-E43F-4552-9711-093603617EAE}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1C737A9F-69EA-4E5E-8399-6320A526F0AB}
+	EndGlobalSection
+EndGlobal

--- a/HarmonyPatches/HookLeveldata.cs
+++ b/HarmonyPatches/HookLeveldata.cs
@@ -9,31 +9,102 @@ using System.Reflection;
 namespace Camera2.HarmonyPatches {
 	[HarmonyPatch]
 	static class HookLeveldata {
-		public static IDifficultyBeatmap difficultyBeatmap;
+		public static BeatmapLevel beatmapLevel;
 		public static GameplayModifiers gameplayModifiers;
 		public static bool is360Level = false;
 		public static bool isModdedMap = false;
 		public static bool isWallMap = false;
 
-		[HarmonyPriority(int.MinValue)]
-		[HarmonyPatch(typeof(StandardLevelScenesTransitionSetupDataSO), nameof(StandardLevelScenesTransitionSetupDataSO.Init))]
-		[HarmonyPatch(typeof(MissionLevelScenesTransitionSetupDataSO), nameof(MissionLevelScenesTransitionSetupDataSO.Init))]
+		[HarmonyPatch(
+		typeof(StandardLevelScenesTransitionSetupDataSO),
+		nameof(StandardLevelScenesTransitionSetupDataSO.Init),
+			new Type[] {
+				typeof(string),
+				typeof(BeatmapKey),
+				typeof(BeatmapLevel),
+				typeof(OverrideEnvironmentSettings),
+				typeof(ColorScheme),
+				typeof(ColorScheme),
+				typeof(GameplayModifiers),
+				typeof(PlayerSpecificSettings),
+				typeof(PracticeSettings),
+				typeof(EnvironmentsListModel),
+				typeof(AudioClipAsyncLoader),
+				typeof(BeatmapDataLoader),
+				typeof(string),
+				typeof(BeatmapLevelsModel),
+				typeof(bool),
+				typeof(bool),
+				typeof(RecordingToolManager.SetupData?) 
+			},
+			new ArgumentType[] { 
+				ArgumentType.Normal,
+				ArgumentType.Ref,
+				ArgumentType.Normal, 
+				ArgumentType.Normal, 
+				ArgumentType.Normal,
+				ArgumentType.Normal, 
+				ArgumentType.Normal,
+				ArgumentType.Normal,
+				ArgumentType.Normal,
+				ArgumentType.Normal,
+				ArgumentType.Normal, 
+				ArgumentType.Normal,
+				ArgumentType.Normal,
+				ArgumentType.Normal,
+				ArgumentType.Normal,
+				ArgumentType.Normal,
+				ArgumentType.Normal
+			}
+		)]
+		[HarmonyPatch(
+			typeof(MissionLevelScenesTransitionSetupDataSO),
+			nameof(MissionLevelScenesTransitionSetupDataSO.Init),
+			new Type[] {
+				typeof(string),
+				typeof(BeatmapKey),
+				typeof(BeatmapLevel),
+				typeof(MissionObjective[]),
+				typeof(ColorScheme),
+				typeof(GameplayModifiers),
+				typeof(PlayerSpecificSettings),
+				typeof(EnvironmentsListModel),
+				typeof(BeatmapLevelsModel),
+				typeof(AudioClipAsyncLoader),
+				typeof(BeatmapDataLoader),
+				typeof(string)
+			},
+			new ArgumentType[] {
+				ArgumentType.Normal,
+				ArgumentType.Ref,
+				ArgumentType.Normal,
+				ArgumentType.Normal,
+				ArgumentType.Normal,
+				ArgumentType.Normal,
+				ArgumentType.Normal,
+				ArgumentType.Normal,
+				ArgumentType.Normal,
+				ArgumentType.Normal,
+				ArgumentType.Normal,
+				ArgumentType.Normal
+			}
+		)]
 		[HarmonyPatch(typeof(MultiplayerLevelScenesTransitionSetupDataSO), nameof(MultiplayerLevelScenesTransitionSetupDataSO.Init))]
-		static void Postfix(IDifficultyBeatmap difficultyBeatmap, GameplayModifiers gameplayModifiers) {
+		static void Postfix(BeatmapKey beatmapKey, BeatmapLevel beatmapLevel, GameplayModifiers gameplayModifiers) {
 #if DEBUG
 			Plugin.Log.Info("Got level data!");
 #endif
-			HookLeveldata.difficultyBeatmap = difficultyBeatmap;
+			HookLeveldata.beatmapLevel = beatmapLevel;
 			HookLeveldata.gameplayModifiers = gameplayModifiers;
 
-			isModdedMap = ModMapUtil.IsModdedMap(difficultyBeatmap);
-			is360Level = difficultyBeatmap.parentDifficultyBeatmapSet.beatmapCharacteristic.containsRotationEvents;
-			isWallMap = ModMapUtil.IsProbablyWallmap(difficultyBeatmap);
+			isModdedMap = ModMapUtil.IsModdedMap(beatmapLevel, beatmapKey);
+			is360Level = beatmapKey.beatmapCharacteristic.containsRotationEvents;
+			isWallMap = ModMapUtil.IsProbablyWallmap(beatmapLevel, beatmapKey);
 		}
 
 		internal static void Reset() {
 			is360Level = isModdedMap = isWallMap = false;
-			difficultyBeatmap = null;
+			beatmapLevel = null;
 		}
 	}
 }

--- a/HarmonyPatches/HookLeveldata.cs
+++ b/HarmonyPatches/HookLeveldata.cs
@@ -15,81 +15,23 @@ namespace Camera2.HarmonyPatches {
 		public static bool isModdedMap = false;
 		public static bool isWallMap = false;
 
-		[HarmonyPatch(
-		typeof(StandardLevelScenesTransitionSetupDataSO),
-		nameof(StandardLevelScenesTransitionSetupDataSO.Init),
-			new Type[] {
-				typeof(string),
-				typeof(BeatmapKey),
-				typeof(BeatmapLevel),
-				typeof(OverrideEnvironmentSettings),
-				typeof(ColorScheme),
-				typeof(ColorScheme),
-				typeof(GameplayModifiers),
-				typeof(PlayerSpecificSettings),
-				typeof(PracticeSettings),
-				typeof(EnvironmentsListModel),
-				typeof(AudioClipAsyncLoader),
-				typeof(BeatmapDataLoader),
-				typeof(string),
-				typeof(BeatmapLevelsModel),
-				typeof(bool),
-				typeof(bool),
-				typeof(RecordingToolManager.SetupData?) 
-			},
-			new ArgumentType[] { 
-				ArgumentType.Normal,
-				ArgumentType.Ref,
-				ArgumentType.Normal, 
-				ArgumentType.Normal, 
-				ArgumentType.Normal,
-				ArgumentType.Normal, 
-				ArgumentType.Normal,
-				ArgumentType.Normal,
-				ArgumentType.Normal,
-				ArgumentType.Normal,
-				ArgumentType.Normal, 
-				ArgumentType.Normal,
-				ArgumentType.Normal,
-				ArgumentType.Normal,
-				ArgumentType.Normal,
-				ArgumentType.Normal,
-				ArgumentType.Normal
-			}
-		)]
-		[HarmonyPatch(
-			typeof(MissionLevelScenesTransitionSetupDataSO),
-			nameof(MissionLevelScenesTransitionSetupDataSO.Init),
-			new Type[] {
-				typeof(string),
-				typeof(BeatmapKey),
-				typeof(BeatmapLevel),
-				typeof(MissionObjective[]),
-				typeof(ColorScheme),
-				typeof(GameplayModifiers),
-				typeof(PlayerSpecificSettings),
-				typeof(EnvironmentsListModel),
-				typeof(BeatmapLevelsModel),
-				typeof(AudioClipAsyncLoader),
-				typeof(BeatmapDataLoader),
-				typeof(string)
-			},
-			new ArgumentType[] {
-				ArgumentType.Normal,
-				ArgumentType.Ref,
-				ArgumentType.Normal,
-				ArgumentType.Normal,
-				ArgumentType.Normal,
-				ArgumentType.Normal,
-				ArgumentType.Normal,
-				ArgumentType.Normal,
-				ArgumentType.Normal,
-				ArgumentType.Normal,
-				ArgumentType.Normal,
-				ArgumentType.Normal
-			}
-		)]
-		[HarmonyPatch(typeof(MultiplayerLevelScenesTransitionSetupDataSO), nameof(MultiplayerLevelScenesTransitionSetupDataSO.Init))]
+		[HarmonyTargetMethods]
+		static IEnumerable<MethodBase> TargetMethods() {
+			foreach(var m in AccessTools.GetDeclaredMethods(typeof(StandardLevelScenesTransitionSetupDataSO)))
+				if(m.Name == nameof(StandardLevelScenesTransitionSetupDataSO.Init))
+					yield return m;
+
+			foreach(var m in AccessTools.GetDeclaredMethods(typeof(MissionLevelScenesTransitionSetupDataSO)))
+				if(m.Name == nameof(MissionLevelScenesTransitionSetupDataSO.Init))
+					yield return m;
+
+			yield return AccessTools.FirstMethod(
+				typeof(MultiplayerLevelScenesTransitionSetupDataSO),
+				x => x.Name == "Init"
+			);
+		}
+
+		[HarmonyPostfix]
 		static void Postfix(BeatmapKey beatmapKey, BeatmapLevel beatmapLevel, GameplayModifiers gameplayModifiers) {
 #if DEBUG
 			Plugin.Log.Info("Got level data!");

--- a/Utils/ModMaps.cs
+++ b/Utils/ModMaps.cs
@@ -9,7 +9,7 @@ namespace Camera2.Utils {
 		static bool hasSongCore =
 			PluginManager.EnabledPlugins.Any(x => x.Name == "SongCore"); // failsafe, Noodle / MapEx do require it themselves technically
 
-		public static bool IsProbablyWallmap(IDifficultyBeatmap map) {
+		public static bool IsProbablyWallmap(BeatmapLevel map, BeatmapKey beatmapKey) {
 			if(!isModCapable)
 				return false;
 
@@ -17,20 +17,20 @@ namespace Camera2.Utils {
 			// if(map.beatmapData.obstaclesCount != 0 && map.beatmapData.obstaclesCount < 100)
 			// 	return false;
 
-			return IsModdedMap(map);
+			return IsModdedMap(map, beatmapKey);
 		}
 
-		public static bool IsModdedMap(IDifficultyBeatmap map) {
+		public static bool IsModdedMap(BeatmapLevel map, BeatmapKey beatmapKey) {
 			if(!hasSongCore || !isModCapable)
 				return false;
 
-			return _IsModdedMap(map);
+			return _IsModdedMap(map, beatmapKey);
 		}
 
 		// Seperate method so we dont throw if theres no Songcore
-		static bool _IsModdedMap(IDifficultyBeatmap map) {
+		static bool _IsModdedMap(BeatmapLevel map, BeatmapKey beatmapKey) {
 			try {
-				return map != null && SongCore.Collections.RetrieveDifficultyData(map)?
+				return map != null && SongCore.Collections.RetrieveDifficultyData(map, beatmapKey)?
 					.additionalDifficultyData?
 					._requirements?.Any(x => x == "Mapping Extensions" || x == "Noodle Extensions") == true;
 			} catch {


### PR DESCRIPTION
beat games changed up the map structure in 1.34.4+ but luckily the hooks are in the same place. Had to add types to the harmony patches because there are now separate Inits for `StandardLevelScenesTransitionSetupDataSO` and `MissionLevelScenesTransitionSetupDataSO`